### PR TITLE
Github Action needs to execute when push to master for actual deployment

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
We had the name "main" instead of "master" in the terraform.yml.  This fix should get the push to happen when we merge to main.